### PR TITLE
use restricted-scc in provider deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ IBM Crossplane is a fork from an opensource project Crossplane with additonal en
 
 ## Requirements
 
-- go 1.14.x
+- go 1.14.x or go 1.15.x
 - helm 3.x
 
 ## Supported platforms

--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -25,6 +25,7 @@
 BUILD_LOCALLY ?= 1
 IMAGE_NAME ?= ibm-crossplane
 RELEASE_VERSION ?= $(shell cat RELEASE_VERSION)
+GO_SUPPORTED_VERSIONS = 1.14|1.15
 
 ifeq ($(BUILD_LOCALLY),0)
     export CONFIG_DOCKER_TARGET = config-docker

--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	replicas                 = int32(1)
-	runAsUser                = int64(2000)
-	runAsGroup               = int64(2000)
+	replicas = int32(1)
+	// IBM Patch: Disable to run with restricted-scc in OpenShift
+	// runAsUser                = int64(2000)
+	// runAsGroup               = int64(2000)
 	allowPrivilegeEscalation = false
 	privileged               = false
 	runAsNonRoot             = true
@@ -68,8 +69,9 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 				Spec: corev1.PodSpec{
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
-						RunAsUser:    &runAsUser,
-						RunAsGroup:   &runAsGroup,
+						// IBM Patch: Disable to run with restricted-scc in OpenShift
+						// RunAsUser:    &runAsUser,
+						// RunAsGroup:   &runAsGroup,
 					},
 					ServiceAccountName: s.GetName(),
 					ImagePullSecrets:   revision.GetPackagePullSecrets(),
@@ -79,8 +81,9 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 							Image:           provider.Spec.Controller.Image,
 							ImagePullPolicy: pullPolicy,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser:                &runAsUser,
-								RunAsGroup:               &runAsGroup,
+								// IBM Patch: Disable to run with restricted-scc in OpenShift
+								// RunAsUser:                &runAsUser,
+								// RunAsGroup:               &runAsGroup,
 								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 								Privileged:               &privileged,
 								RunAsNonRoot:             &runAsNonRoot,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

Removes runAsUser and runAsGroup in provider deployment, so the pod can be run with restricted scc in OpenShift

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
