### PR TITLE
set connection secret default namespace

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -412,7 +412,14 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 		// that we'll propagate any connection details during a future
 		// iteration.
 		s := &corev1.Secret{}
-		nn := types.NamespacedName{Namespace: sref.Namespace, Name: sref.Name}
+
+		// IBM Patch: Default the connection secret namespace to the composed resource namespace
+		n := sref.Namespace
+		if n == "" {
+			n = cd.GetNamespace()
+		}
+		// nn := types.NamespacedName{Namespace: sref.Namespace, Name: sref.Name}
+		nn := types.NamespacedName{Namespace: n, Name: sref.Name}
 		if err := cdf.client.Get(ctx, nn, s); client.IgnoreNotFound(err) != nil {
 			return nil, errors.Wrap(err, errGetSecret)
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
if writeConnectionSecretsToNamespace in composition is not defined, default to the namespace where crossplane is deployed

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
