### PR TITLE
Crossplane 1.0: backport pr2120 to support fromFieldPath

### DIFF
--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -520,6 +520,17 @@ func (s *ConvertTransform) Resolve(input interface{}) (interface{}, error) {
 	return f(input)
 }
 
+// A ConnectionDetailType is a type of connection detail.
+type ConnectionDetailType string
+
+// ConnectionDetailType types.
+const (
+	ConnectionDetailTypeUnknown                 ConnectionDetailType = "Unknown"
+	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey"
+	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
+	ConnectionDetailTypeFromValue               ConnectionDetailType = "FromValue"
+)
+
 // ConnectionDetail includes the information about the propagation of the connection
 // information from one secret to another.
 type ConnectionDetail struct {
@@ -529,10 +540,24 @@ type ConnectionDetail struct {
 	// +optional
 	Name *string `json:"name,omitempty"`
 
+	// Type sets the connection detail fetching behaviour to be used. Each
+	// connection detail type may require its own fields to be set on the
+	// ConnectionDetail object. If the type is omitted Crossplane will attempt
+	// to infer it based on which other fields were specified.
+	// +optional
+	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;FromValue
+	Type *ConnectionDetailType `json:"type,omitempty"`
+
 	// FromConnectionSecretKey is the key that will be used to fetch the value
-	// from the given target resource.
+	// from the given target resource's secret.
 	// +optional
 	FromConnectionSecretKey *string `json:"fromConnectionSecretKey,omitempty"`
+
+	// FromFieldPath is the path of the field on the composed resource whose
+	// value to be used as input. Name must be specified if the type is
+	// FromFieldPath is specified.
+	// +optional
+	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 
 	// Value that will be propagated to the connection secret of the composition
 	// instance. Typically you should use FromConnectionSecretKey instead, but

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -356,8 +356,18 @@ func (in *ConnectionDetail) DeepCopyInto(out *ConnectionDetail) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Type != nil {
+		in, out := &in.Type, &out.Type
+		*out = new(ConnectionDetailType)
+		**out = **in
+	}
 	if in.FromConnectionSecretKey != nil {
 		in, out := &in.FromConnectionSecretKey, &out.FromConnectionSecretKey
+		*out = new(string)
+		**out = **in
+	}
+	if in.FromFieldPath != nil {
+		in, out := &in.FromFieldPath, &out.FromFieldPath
 		*out = new(string)
 		**out = **in
 	}

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -151,10 +151,20 @@ spec:
                         description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
+                            type: string
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
                             type: string
                           name:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          type:
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
+                            enum:
+                            - FromConnectionSecretKey
+                            - FromFieldPath
+                            - FromValue
                             type: string
                           value:
                             description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
Backport [pr2120](https://github.com/crossplane/crossplane/pull/2120) to Crossplane 1.0 to support `fromFieldPath` in `connectionDetails`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
