### PR TITLE
Fix img.build target causing errors in prow tests

### DIFF
--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -12,7 +12,7 @@ include ../../../build/makelib/image.mk
 # ====================================================================================
 # Targets
 
-ifeq ($(PLATFORM),$(filter $(PLATFORM),darwin_amd64 windows_amd64)) 
+ifeq ($(PLATFORM),$(filter $(PLATFORM),darwin_amd64 windows_amd64))
 $(info Skipping image build for $(PLATFORM))
 img.build:
 else
@@ -22,7 +22,6 @@ img.build:
 	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/crossplane $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@docker build $(BUILD_ARGS) \
-		--platform linux/$(ARCH) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
 	@$(OK) docker build $(IMAGE)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Remove `--platform` flag in target `img.build` from `cluster/images/crossplane/Makefie` that is causing errors in prow tests in [`ibm-crossplane-operator`](https://github.com/IBM/ibm-crossplane-operator)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
